### PR TITLE
Remove pbugnion as maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,5 +46,4 @@ about:
 extra:
   recipe-maintainers:
     - holtgrewe
-    - pbugnion
     - tcbegley


### PR DESCRIPTION
@pbugnion - I noticed that each time there's a PR you're getting added as a maintainer, I assume that's because you are manually leaving the conda-forge organisation in between releases? If you don't want the notification spam, we can merge this and you should be able to leave.